### PR TITLE
Fix for nullable integers & underscores causing mismatch of propertynames

### DIFF
--- a/src/Patcheetah/Patching/EntityPatcher.cs
+++ b/src/Patcheetah/Patching/EntityPatcher.cs
@@ -72,6 +72,8 @@ namespace Patcheetah.Patching
             var propertyConfig = config?[property.Name];
             var propertyName = propertyConfig?.Name ?? property.Name;
 
+            if (propertyName.StartsWith("_")) propertyName = propertyName.TrimStart('_');  //this fixes where propertyNames have had an underscore appended (because of numeric values in JSON) but will break any properties which actually start with underscore!
+
             if (!patchData.ContainsKey(propertyName))
             {
                 return;


### PR DESCRIPTION
Fixed two issues encountered with the library.

First was incorrect handling of nullable integers in the patching model.

Second is the situation where an underscore is added to the name of a property in the model because it would otherwise be illegal:  e.g.

        /// <summary>
        /// Gets or Sets _01
        /// </summary>
        [DataMember(Name="01")]
        public AudioPackageAudioLevel _01 { get; set; }

My less than ideal solution is simply to strip out the underscore from the property name but this could well break stuff when underscores were deliberately added but that solution worked for my situation